### PR TITLE
battery updates

### DIFF
--- a/example/c++/main.cpp
+++ b/example/c++/main.cpp
@@ -8,7 +8,7 @@ int main()
 {
     cout << "power supply: " << glug_power_active_supply() << endl;
     cout << "battery state: " << glug_power_battery_state() << endl;
-    cout << "battery %: " << static_cast<int>(glug_power_battery_pct()) << endl;
+    cout << "battery %: " << static_cast<int>(glug_power_battery_level()) << endl;
 
     const long long time = glug_power_battery_time();
     cout << "time left: " << time / 60 / 60 << ':' << time / 60 % 60 << ':' << time % 60 << endl;

--- a/example/c/main.c
+++ b/example/c/main.c
@@ -6,7 +6,7 @@ int main()
 {
     printf("power supply: %d\n", glug_power_active_supply());
     printf("battery state: %d\n", glug_power_battery_state());
-    printf("battery %%: %d\n", glug_power_battery_pct());
+    printf("battery %%: %d\n", glug_power_battery_level());
 
     const long long time = glug_power_battery_time();
     printf("time left: %lld:%02lld:%02lld\n", time / 60 / 60, time / 60 % 60, time % 60);

--- a/glug_power/common_src.cmake
+++ b/glug_power/common_src.cmake
@@ -2,7 +2,7 @@ set(
     COMMON_SOURCE
     common_headers/include/glug/allocator_t.h
     common_headers/include/glug/std_allocator.inl
-    common_headers/include/glug/bool.h
+    common_headers/include/glug/bool_t.h
     common_headers/include/glug/extern.h
     common_headers/include/glug/import.h
     common_headers/include/glug/os.h

--- a/glug_power/include/glug/power/power.h
+++ b/glug_power/include/glug/power/power.h
@@ -13,8 +13,8 @@ GLUG_EXTERN_START
 
 GLUG_LIB_API enum glug_power_supply   glug_power_active_supply(void);
 GLUG_LIB_API enum glug_battery_status glug_power_battery_state(void);
-GLUG_LIB_API int8_t                   glug_power_battery_pct(void);
-GLUG_LIB_API int64_t                  glug_power_battery_time(void);
+GLUG_LIB_API int8_t                   glug_power_battery_level(void);
+GLUG_LIB_API int32_t                  glug_power_battery_time(void);
 
 GLUG_EXTERN_END
 

--- a/glug_power/src/iops/ac.c
+++ b/glug_power/src/iops/ac.c
@@ -4,11 +4,13 @@
 #include <IOKit/ps/IOPowerSources.h>
 #include <IOKit/ps/IOPSKeys.h>
 
-glug_bool ac_connected(void)
+#include <glug/bool_t.h>
+
+glug_bool_t ac_connected(void)
 {
     const CFTypeRef info     = IOPSCopyPowerSourcesInfo();
     const CFStringRef source = IOPSGetProvidingPowerSourceType(info);
-    glug_bool ac = !CFStringCompare(source, CFSTR(kIOPMACPowerKey), 0);
+    glug_bool_t ac = !CFStringCompare(source, CFSTR(kIOPMACPowerKey), 0);
 
     CFRelease(info);
     return ac;

--- a/glug_power/src/iops/iops.h
+++ b/glug_power/src/iops/iops.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#include <glug/bool.h>
+#include <glug/bool_t.h>
 
 struct battery_info
 {
@@ -13,7 +13,7 @@ struct battery_info
     size_t ncharged;
 };
 
-GLUG_LIB_LOCAL glug_bool    ac_connected(void);
+GLUG_LIB_LOCAL glug_bool_t  ac_connected(void);
 GLUG_LIB_LOCAL void         battery_info(struct battery_info *);
 
 GLUG_LIB_LOCAL int8_t       battery_life_percent(void);

--- a/glug_power/src/power.c
+++ b/glug_power/src/power.c
@@ -42,12 +42,12 @@ enum glug_battery_status glug_power_battery_state(void)
     return status;
 }
 
-int8_t glug_power_battery_pct(void)
+int8_t glug_power_battery_level(void)
 {
-    return battery_pct();
+    return battery_level();
 }
 
-int64_t glug_power_battery_time(void)
+int32_t glug_power_battery_time(void)
 {
     return battery_time();
 }

--- a/glug_power/src/power.c
+++ b/glug_power/src/power.c
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include <glug/bool_t.h>
 #include "battery_state_t.h"
 
 enum glug_power_supply glug_power_active_supply(void)
@@ -23,7 +24,7 @@ enum glug_battery_status glug_power_battery_state(void)
     battery_state(&batteries);
 
     enum glug_battery_status status = glug_battery_unknown;
-    glug_bool ac = has_ac();
+    glug_bool_t ac = has_ac();
 
     if (!batteries.count && ac)
         status = glug_battery_none;

--- a/glug_power/src/power_bridge.h
+++ b/glug_power/src/power_bridge.h
@@ -12,7 +12,7 @@ GLUG_LIB_LOCAL glug_bool    has_ac(void);
 GLUG_LIB_LOCAL void         battery_count(size_t *);
 GLUG_LIB_LOCAL void         battery_state(struct battery_state *);
 
-GLUG_LIB_LOCAL int8_t       battery_pct (void);
-GLUG_LIB_LOCAL int64_t      battery_time(void);
+GLUG_LIB_LOCAL int8_t       battery_level(void);
+GLUG_LIB_LOCAL int32_t      battery_time (void);
 
 #endif // GLUG_POWER_BRIDGE_H

--- a/glug_power/src/power_bridge.h
+++ b/glug_power/src/power_bridge.h
@@ -4,11 +4,11 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#include <glug/bool.h>
+#include <glug/bool_t.h>
 
 struct battery_state;
 
-GLUG_LIB_LOCAL glug_bool    has_ac(void);
+GLUG_LIB_LOCAL glug_bool_t  has_ac(void);
 GLUG_LIB_LOCAL void         battery_count(size_t *);
 GLUG_LIB_LOCAL void         battery_state(struct battery_state *);
 

--- a/glug_power/src/power_bridge_linux.c
+++ b/glug_power/src/power_bridge_linux.c
@@ -26,12 +26,12 @@ void battery_state(struct battery_state *state)
     state->ncharged  = batteries.ncharged;
 }
 
-int8_t battery_pct(void)
+int8_t battery_level(void)
 {
     return battery_life_percent();
 }
 
-int64_t battery_time(void)
+int32_t battery_time(void)
 {
     return battery_life_time();
 }

--- a/glug_power/src/power_bridge_linux.c
+++ b/glug_power/src/power_bridge_linux.c
@@ -3,7 +3,9 @@
 #include "battery_state_t.h"
 #include "sysfs/sysfs.h"
 
-glug_bool has_ac(void)
+#include <glug/bool_t.h>
+
+glug_bool_t has_ac(void)
 {
     return ac_connected();
 }

--- a/glug_power/src/power_bridge_osx.c
+++ b/glug_power/src/power_bridge_osx.c
@@ -26,12 +26,12 @@ void battery_state(struct battery_state *state)
     state->ncharged  = batteries.ncharged;
 }
 
-int8_t battery_pct()
+int8_t battery_level()
 {
     return (int8_t)battery_life_percent();
 }
 
-int64_t battery_time()
+int32_t battery_time()
 {
-    return (int64_t)battery_life_time();
+    return battery_life_time();
 }

--- a/glug_power/src/power_bridge_osx.c
+++ b/glug_power/src/power_bridge_osx.c
@@ -3,7 +3,9 @@
 #include "battery_state_t.h"
 #include "iops/iops.h"
 
-glug_bool has_ac(void)
+#include <glug/bool_t.h>
+
+glug_bool_t has_ac(void)
 {
     return ac_connected();
 }

--- a/glug_power/src/power_bridge_win32.c
+++ b/glug_power/src/power_bridge_win32.c
@@ -3,7 +3,9 @@
 #include "battery_state_t.h"
 #include "system_power_status/system_power_status.h"
 
-glug_bool has_ac(void)
+#include <glug/bool_t.h>
+
+glug_bool_t has_ac(void)
 {
     return ac_connected();
 }

--- a/glug_power/src/power_bridge_win32.c
+++ b/glug_power/src/power_bridge_win32.c
@@ -22,12 +22,12 @@ void battery_state(struct battery_state *state)
     state->ncharging = charge_state == cs_charging;
 }
 
-int8_t battery_pct(void)
+int8_t battery_level(void)
 {
     return battery_life_percent();
 }
 
-int64_t battery_time(void)
+int32_t battery_time(void)
 {
-    return (int64_t)battery_life_time();
+    return battery_life_time();
 }

--- a/glug_power/src/sysfs/ac.c
+++ b/glug_power/src/sysfs/ac.c
@@ -2,9 +2,11 @@
 
 #include <stdio.h>
 
+#include <glug/bool_t.h>
+
 static const char *ac_online_file = "/sys/class/power_supply/ACAD/online";
 
-glug_bool ac_connected(void)
+glug_bool_t ac_connected(void)
 {
     long val = -1;
     FILE *fonline = fopen(ac_online_file, "r");

--- a/glug_power/src/sysfs/sysfs.h
+++ b/glug_power/src/sysfs/sysfs.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#include <glug/bool.h>
+#include <glug/bool_t.h>
 
 struct battery_list;
 
@@ -15,10 +15,10 @@ struct battery_info
     size_t ncharged;
 };
 
-GLUG_LIB_LOCAL glug_bool ac_connected(void);
-GLUG_LIB_LOCAL void      battery_info(struct battery_info *);
+GLUG_LIB_LOCAL glug_bool_t ac_connected(void);
+GLUG_LIB_LOCAL void        battery_info(struct battery_info *);
 
-GLUG_LIB_LOCAL int8_t   battery_life_percent(void);
-GLUG_LIB_LOCAL int32_t  battery_life_time(void);
+GLUG_LIB_LOCAL int8_t      battery_life_percent(void);
+GLUG_LIB_LOCAL int32_t     battery_life_time(void);
 
 #endif // GLUG_SYSFS_H

--- a/glug_power/src/system_power_status/ac.c
+++ b/glug_power/src/system_power_status/ac.c
@@ -1,12 +1,12 @@
 #include "system_power_status.h"
 
-#include <glug/bool.h>
+#include <glug/bool_t.h>
 
 #define VC_EXTRALEAN
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
-glug_bool ac_connected(void)
+glug_bool_t ac_connected(void)
 {
     SYSTEM_POWER_STATUS ps;
     GetSystemPowerStatus(&ps);

--- a/glug_power/src/system_power_status/battery.c
+++ b/glug_power/src/system_power_status/battery.c
@@ -1,17 +1,17 @@
 #include "system_power_status.h"
 
-#include <glug/bool.h>
+#include <glug/bool_t.h>
 
 #define VC_EXTRALEAN
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
-static glug_bool has_battery(const SYSTEM_POWER_STATUS *ps)
+static glug_bool_t has_battery(const SYSTEM_POWER_STATUS *ps)
 {
     return !(ps->BatteryFlag == BATTERY_FLAG_UNKNOWN || ps->BatteryFlag & BATTERY_FLAG_NO_BATTERY);
 }
 
-glug_bool battery_connected(void)
+glug_bool_t battery_connected(void)
 {
     SYSTEM_POWER_STATUS ps;
     GetSystemPowerStatus(&ps);

--- a/glug_power/src/system_power_status/system_power_status.h
+++ b/glug_power/src/system_power_status/system_power_status.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-#include <glug/bool.h>
+#include <glug/bool_t.h>
 
 enum charge_state
 {
@@ -14,8 +14,8 @@ enum charge_state
     cs_charged,
 };
 
-GLUG_LIB_LOCAL glug_bool ac_connected(void);
-GLUG_LIB_LOCAL glug_bool battery_connected(void);
+GLUG_LIB_LOCAL glug_bool_t ac_connected(void);
+GLUG_LIB_LOCAL glug_bool_t battery_connected(void);
 
 GLUG_LIB_LOCAL enum charge_state battery_charge_state(void);
 GLUG_LIB_LOCAL int8_t   battery_life_percent(void);


### PR DESCRIPTION
- rename `glug_power_battery_pct` to `glug_power_battery_level`
- fix Mac OS battery time